### PR TITLE
Fix to get the correct next close price

### DIFF
--- a/lab-12-5-rnn_stock_prediction.py
+++ b/lab-12-5-rnn_stock_prediction.py
@@ -24,7 +24,7 @@ dataX = []
 dataY = []
 for i in range(0, len(y) - seq_length):
     _x = x[i:i + seq_length]
-    _y = y[i + 1]  # Next close price
+    _y = y[i + seq_length]  # Next close price
     print(_x, "->", _y)
     dataX.append(_x)
     dataY.append(_y)


### PR DESCRIPTION
안녕하세요.  교수님의 강의로 텐서플로우를 시작한 시드니의 늙은 개발자입니다.
멋진 예제를 잘 보았습니다.
그런데 한가지 이상한 부분이 있어서 리포트를 합니다.
lab-12-5-rnn_stock_prediction.py:27 과 같이 "Next close price"를 가지고 오면, _x[1][-1]==_y 값이 같이지므로, _y label 값은 이미 Training data에 포함되게 되는 것으로 생각됩니다.
제 나름대로 고친 부분을  보내드리니 검토 부탁드립니다.

그리고, 말씀드린데로 고치게 되면 (안타깝게도) prediction 값이 forecasting을 한다기 보다는 뒷 따르는 결과를 보여줍니다.  하하, 만약 처음 코드처럼 prediction이 forecasting을 하는 것 처럼 보여준다면 얼마나 좋을까요? 하하.

항상 열정적인 강의에 감사드립니다.
특히 이번 예제 코드는 정말 훌륭합니다.
혹 시드니에 들리 실 일이 계시면 식사한번 대접하겠습니다.

감사합니다.
정진규 드림.