### PR TITLE
refactor: tf variable init method updated

### DIFF
--- a/lab-09-3-linear_back_prop.py
+++ b/lab-09-3-linear_back_prop.py
@@ -43,7 +43,8 @@ step = [
 RMSE = tf.reduce_mean(tf.square((Y - hypothesis)))
 
 sess = tf.InteractiveSession()
-sess.run(tf.initialize_all_variables())
+init = tf.global_variables_initializer()
+sess.run(init)
 
 for i in range(1000):
     print(i, sess.run([step, RMSE], feed_dict={X: x_data, Y: y_data}))

--- a/lab-09-4-multi-linear_back_prop.py
+++ b/lab-09-4-multi-linear_back_prop.py
@@ -45,7 +45,8 @@ step = [
 RMSE = tf.reduce_mean(tf.square((Y - hypothesis)))
 
 sess = tf.InteractiveSession()
-sess.run(tf.initialize_all_variables())
+init = tf.global_variables_initializer()
+sess.run(init)
 
 for i in range(10000):
     print(i, sess.run([step, RMSE], feed_dict={X: x_data, Y: y_data}))


### PR DESCRIPTION
- `tf.initialize_all_variables()`method has been deprecated
- change to `tf.global_variables_initializer()` 