### PR TITLE
Update lab-06-2-softmax_zoo_classifier.py

### DIFF
--- a/lab-06-2-softmax_zoo_classifier.py
+++ b/lab-06-2-softmax_zoo_classifier.py
@@ -27,10 +27,9 @@ logits = tf.matmul(X, W) + b
 hypothesis = tf.nn.softmax(logits)
 
 # Cross entropy cost/loss
-cost_i = tf.nn.softmax_cross_entropy_with_logits(logits=logits,
-                                                 labels=Y_one_hot)
+cost_i = -tf.reduce_sum(Y_one_hot*tf.log(hypothesis))
 cost = tf.reduce_mean(cost_i)
-optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.1).minimize(cost)
+optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.01).minimize(cost)
 
 prediction = tf.argmax(hypothesis, 1)
 correct_prediction = tf.equal(prediction, tf.argmax(Y_one_hot, 1))


### PR DESCRIPTION
lab-06-2-softmax_zoo_classifier.py에서 tf.nn.softmax과 tf.nn.softmax_cross_entropy_with_logits가 같이 사용되어 개념이 혼동되어 Tensorflow 공식페이지를 찾아보았습니다. tf.nn.softmax_cross_entropy_with_logits가 내부적으로 softmax를 적용시키므로 tf.nn.softmax를 같이 적용시키지 않는다는 것을 확인했습니다.

참고1 : https://www.tensorflow.org/get_started/mnist/beginners
참고2 : https://www.tensorflow.org/get_started/mnist/pros
참고3 : https://www.facebook.com/groups/TensorFlowKR/permalink/399110030430061/?comment_id=399110370430027&reply_comment_id=399110850429979