### PR TITLE
Error at 41st line print(step,sess.run([gradient, W, gvs])) in certain environment.

### DIFF
--- a/lab-03-X-minimizing_cost_tf_gradient.py
+++ b/lab-03-X-minimizing_cost_tf_gradient.py
@@ -35,6 +35,8 @@ sess = tf.Session()
 # Initializes global variables in the graph.
 sess.run(tf.global_variables_initializer())
 
+tf.reset_default_graph()
+
 for step in range(100):
     print(step, sess.run([gradient, W, gvs]))
     sess.run(apply_gradients)


### PR DESCRIPTION
In environments such as Jupiter Laptops, I found it on the Internet that the contexts of variables are maintained as long as the Jupiter kernel is not restarted. So, if you create the same graph again without erasing the graph, you may get an error.
Having resetting the default graph on line 38, error has been fixed. It may be useful when error is occurred in certain environments.
source : http://bcho.tistory.com/1156 [조대협의 블로그]