### PR TITLE
Derivative term Error in Back propagation through sigmoid activation function.

### DIFF
--- a/lab-10-X1-mnist_back_prop.py
+++ b/lab-10-X1-mnist_back_prop.py
@@ -40,7 +40,7 @@ diff = (y_pred - Y)
 
 
 # Back prop (chain rule)
-d_l2 = diff * sigma_prime(l2)
+d_l2 = diff
 d_b2 = d_l2
 d_w2 = tf.matmul(tf.transpose(a1), d_l2)
 


### PR DESCRIPTION
In back propagation over sigmoid activation function, the derivative 
term between output layer and activation should result in **y - t**
(error value: prediction - label). Therfore `d_l2` value should be `diff` not `diff * sigma_prime(l2)`.
(https://docs.google.com/presentation/d/1_ZmtfEjLmhbuM_PqbDYMXXLAqeWN0HwuhcSKnUQZ6MM/edit#slide=id.p6)