### PR TITLE
remove UserWarning(remove learning rate from compile())

### DIFF
--- a/Keras/klab-04-1-multi_input_linear_regression.py
+++ b/Keras/klab-04-1-multi_input_linear_regression.py
@@ -1,5 +1,6 @@
 from keras.models import Sequential
 from keras.layers import Dense, Activation
+from keras.optimizers import RMSprop
 import numpy as np
 
 x_data = [[73., 80., 75.],
@@ -17,7 +18,8 @@ model = Sequential()
 model.add(Dense(input_dim=3, units=1))
 model.add(Activation('linear'))
 
-model.compile(loss='mse', optimizer='rmsprop', lr=1e-10)
+rmsprop = RMSprop(lr=1e-10)
+model.compile(loss='mse', optimizer=rmsprop)
 model.fit(x_data, y_data, epochs=1000)
 
 y_predict = model.predict(np.array([[95., 100., 80]]))

--- a/Keras/klab-05-1-logistic_regression.py
+++ b/Keras/klab-05-1-logistic_regression.py
@@ -1,5 +1,6 @@
 from keras.models import Sequential
 from keras.layers import Dense
+from keras.optimizers import SGD
 import numpy as np
 
 x_data = [[1, 2],
@@ -18,7 +19,8 @@ y_data = [[0],
 model = Sequential()
 model.add(Dense(1, input_dim=2, activation='sigmoid'))
 
-model.compile(loss='binary_crossentropy', optimizer='sgd', lr=0.1)
+sgd = SGD(lr=0.1)
+model.compile(loss='binary_crossentropy', optimizer=sgd)
 
 model.summary()
 model.fit(x_data, y_data, epochs=2000)

--- a/Keras/klab-05-2-logistic_regression_diabetes.py
+++ b/Keras/klab-05-2-logistic_regression_diabetes.py
@@ -1,5 +1,6 @@
 from keras.models import Sequential
 from keras.layers import Dense
+from keras.optimizers import SGD
 import numpy as np
 
 x_data = [[1, 2],
@@ -18,7 +19,8 @@ y_data = [[0],
 model = Sequential()
 model.add(Dense(1, input_dim=2, activation='sigmoid'))
 
-model.compile(loss='binary_crossentropy', optimizer='sgd', lr=0.1)
+sgd = SGD(lr=0.1)
+model.compile(loss='binary_crossentropy', optimizer=sgd)
 
 model.summary()
 model.fit(x_data, y_data, epochs=2000)

--- a/Keras/klab-09-1-xor.py
+++ b/Keras/klab-09-1-xor.py
@@ -1,5 +1,6 @@
 from keras.models import Sequential
 from keras.layers import Dense
+from keras.optimizers import SGD
 
 x_data = [[0., 0.],
           [0., 1.],
@@ -12,8 +13,9 @@ y_data = [[0.],
 
 model = Sequential()
 model.add(Dense(1, input_dim=2, activation='sigmoid'))
-model.compile(loss='binary_crossentropy', optimizer='sgd',
-              lr=0.1, metrics=['accuracy'])
+sgd = SGD(lr=0.1)
+model.compile(loss='binary_crossentropy', optimizer=sgd,
+              metrics=['accuracy'])
 model.summary()
 model.fit(x_data, y_data, epochs=50000)
 

--- a/Keras/klab-09-2-xor-nn.py
+++ b/Keras/klab-09-2-xor-nn.py
@@ -1,5 +1,6 @@
 from keras.models import Sequential
 from keras.layers import Dense
+from keras.optimizers import SGD
 
 x_data = [[0., 0.],
           [0., 1.],
@@ -13,8 +14,9 @@ y_data = [[0.],
 model = Sequential()
 model.add(Dense(2, input_dim=2, activation='sigmoid'))
 model.add(Dense(1, activation='sigmoid'))
-model.compile(loss='binary_crossentropy', optimizer='sgd',
-              lr=0.1, metrics=['accuracy'])
+sgd = SGD(lr=0.1)
+model.compile(loss='binary_crossentropy', optimizer=sgd,
+              metrics=['accuracy'])
 
 model.summary()
 model.fit(x_data, y_data, epochs=50000)

--- a/Keras/klab-10-1-mnist_softmax.py
+++ b/Keras/klab-10-1-mnist_softmax.py
@@ -1,5 +1,6 @@
 from keras.models import Sequential
 from keras.layers import Dense, Activation
+from keras.optimizers import Adam
 from keras import initializers
 from keras.utils import np_utils
 from keras import backend as K
@@ -48,8 +49,9 @@ model.add(Activation('softmax'))
 
 model.summary()
 
+adam = Adam(lr=learning_rate)
 model.compile(loss='categorical_crossentropy',
-              optimizer='adam', learning_rate=learning_rate,
+              optimizer=adam,
               metrics=['accuracy'])
 
 model.fit(X_train, Y_train, batch_size=batch_size, epochs=training_epochs)


### PR DESCRIPTION
this patch removes user warnning below.
```
C:\Users\skyer9\AppData\Local\Programs\Python\Python35\lib\site-packages\keras\b
ackend\tensorflow_backend.py:2124: UserWarning: Expected no kwargs, you passed 1

kwargs passed to function are ignored with Tensorflow backend
  warnings.warn('\n'.join(msg))
Epoch 1/2
6/6 [==============================] - 0s - loss: 1.3499
Epoch 2/2
6/6 [==============================] - 0s - loss: 1.3280
```