### PR TITLE
Modify MultiRNNCell problems

### DIFF
--- a/lab-12-4-rnn_long_char.py
+++ b/lab-12-4-rnn_long_char.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 from tensorflow.contrib import rnn
+
 tf.set_random_seed(777)  # reproducibility
 
 sentence = ("if you want to build a ship, don't drum up people together to "
@@ -39,12 +40,16 @@ Y = tf.placeholder(tf.int32, [None, sequence_length])
 X_one_hot = tf.one_hot(X, num_classes)
 print(X_one_hot)  # check out the shape
 
+
 # Make a lstm cell with hidden_size (each unit output vector size)
-cell = rnn.BasicLSTMCell(hidden_size, state_is_tuple=True)
-cell = rnn.MultiRNNCell([cell] * 2, state_is_tuple=True)
+def lstm_cell():
+    cell = tf.contrib.rnn.BasicLSTMCell(hidden_size, state_is_tuple=True)
+    return cell
+
+multi_cells = tf.contrib.rnn.MultiRNNCell([lstm_cell() for _ in range(2)], state_is_tuple=True)
 
 # outputs: unfolding size x hidden size, state = hidden size
-outputs, _states = tf.nn.dynamic_rnn(cell, X_one_hot, dtype=tf.float32)
+outputs, _states = tf.nn.dynamic_rnn(multi_cells, X_one_hot, dtype=tf.float32)
 
 # FC layer
 X_for_fc = tf.reshape(outputs, [-1, hidden_size])

--- a/lab-12-4-rnn_long_char.py
+++ b/lab-12-4-rnn_long_char.py
@@ -43,10 +43,10 @@ print(X_one_hot)  # check out the shape
 
 # Make a lstm cell with hidden_size (each unit output vector size)
 def lstm_cell():
-    cell = tf.contrib.rnn.BasicLSTMCell(hidden_size, state_is_tuple=True)
+    cell = rnn.BasicLSTMCell(hidden_size, state_is_tuple=True)
     return cell
 
-multi_cells = tf.contrib.rnn.MultiRNNCell([lstm_cell() for _ in range(2)], state_is_tuple=True)
+multi_cells = rnn.MultiRNNCell([lstm_cell() for _ in range(2)], state_is_tuple=True)
 
 # outputs: unfolding size x hidden size, state = hidden size
 outputs, _states = tf.nn.dynamic_rnn(multi_cells, X_one_hot, dtype=tf.float32)


### PR DESCRIPTION
While studying RNN lecture yesterday, I had some problems.
This is my error
![error](https://cloud.githubusercontent.com/assets/17329316/25926215/e59db188-3628-11e7-870c-47857ccc7aab.PNG)

IDE pointed below code.
`cell = rnn.MultiRNNCell([cell] * 2, state_is_tuple=True)`

I don't know exactly what problem is. So I got help from stackoverflow and I could solve this problem.
ref: http://stackoverflow.com/questions/42669578/tensorflow-1-0-valueerror-attempt-to-reuse-rnncell-with-a-different-variable-s
This problem looks like a tensorflow version problem.