### PR TITLE
fix: GradientDescent --> AdamOptimizer

### DIFF
--- a/lab-09-4-xor_tensorboard.py
+++ b/lab-09-4-xor_tensorboard.py
@@ -45,7 +45,7 @@ with tf.name_scope("cost") as scope:
     cost_summ = tf.summary.scalar("cost", cost)
 
 with tf.name_scope("train") as scope:
-    train = tf.train.GradientDescentOptimizer(learning_rate=learning_rate).minimize(cost)
+    train = tf.train.AdamOptimizer(learning_rate=learning_rate).minimize(cost)
 
 # Accuracy computation
 # True if hypothesis>0.5 else False


### PR DESCRIPTION
## Summary

1. `GradientDescentOptimizer()` does not work
- Fix: change to `AdamOptimizer`

## With `GradientDescentOptimizer`
```
Hypothesis:  [[ 0.50004655]
 [ 0.50004429]
 [ 0.50005126]
 [ 0.50004894]] 
Correct:  [[ 1.]
 [ 1.]
 [ 1.]
 [ 1.]] 
Accuracy:  0.5
```

## After change to `AdamOptimizer`
```
Hypothesis:  [[  6.13103257e-05]
 [  9.99936938e-01]
 [  9.99950767e-01]
 [  5.97514700e-05]] 
Correct:  [[ 0.]
 [ 1.]
 [ 1.]
 [ 0.]] 
Accuracy:  1.0
```
