### PR TITLE
remove redundant a line in 'lab-03-1-minimizing_cost_show_graph.py'.

### DIFF
--- a/lab-03-1-minimizing_cost_show_graph.py
+++ b/lab-03-1-minimizing_cost_show_graph.py
@@ -16,8 +16,6 @@ cost = tf.reduce_mean(tf.square(hypothesis - Y))
 
 # Launch the graph in a session.
 sess = tf.Session()
-# Initializes global variables in the graph.
-sess.run(tf.global_variables_initializer())
 
 # Variables for plotting cost function
 W_history = []


### PR DESCRIPTION
As I know, this line is for initializing global Tensorflow variables like 'tf.Variable()', so that it seems redundant.