### PR TITLE
Fixes deprecated `tf.arg_max`

### DIFF
--- a/lab-06-1-softmax_classifier.py
+++ b/lab-06-1-softmax_classifier.py
@@ -48,23 +48,23 @@ with tf.Session() as sess:
 
     # Testing & One-hot encoding
     a = sess.run(hypothesis, feed_dict={X: [[1, 11, 7, 9]]})
-    print(a, sess.run(tf.arg_max(a, 1)))
+    print(a, sess.run(tf.argmax(a, 1)))
 
     print('--------------')
 
     b = sess.run(hypothesis, feed_dict={X: [[1, 3, 4, 3]]})
-    print(b, sess.run(tf.arg_max(b, 1)))
+    print(b, sess.run(tf.argmax(b, 1)))
 
     print('--------------')
 
     c = sess.run(hypothesis, feed_dict={X: [[1, 1, 0, 1]]})
-    print(c, sess.run(tf.arg_max(c, 1)))
+    print(c, sess.run(tf.argmax(c, 1)))
 
     print('--------------')
 
     all = sess.run(hypothesis, feed_dict={
                    X: [[1, 11, 7, 9], [1, 3, 4, 3], [1, 1, 0, 1]]})
-    print(all, sess.run(tf.arg_max(all, 1)))
+    print(all, sess.run(tf.argmax(all, 1)))
 
 '''
 --------------


### PR DESCRIPTION
`tf.arg_max` is deprecated -> `tf.argmax` should be used instead

Related issue: #194 