### PR TITLE
Update lab-07-4-mnist_introduction.py

### DIFF
--- a/lab-07-4-mnist_introduction.py
+++ b/lab-07-4-mnist_introduction.py
@@ -1,5 +1,10 @@
 # Lab 7 Learning rate and Evaluation
 import tensorflow as tf
+
+#remove read_data_sets error
+old_v = tf.logging.get_verbosity()
+tf.logging.set_verbosity(tf.logging.ERROR)
+
 import matplotlib.pyplot as plt
 import random
 

--- a/lab-07-4-mnist_introduction.py
+++ b/lab-07-4-mnist_introduction.py
@@ -1,10 +1,8 @@
 # Lab 7 Learning rate and Evaluation
 import tensorflow as tf
-
 #remove read_data_sets error
 old_v = tf.logging.get_verbosity()
 tf.logging.set_verbosity(tf.logging.ERROR)
-
 import matplotlib.pyplot as plt
 import random
 


### PR DESCRIPTION
recommend remove error message (read_data_sets (from tensorflow.contrib.learn.python.learn.datasets.mnist) is deprecated and will be removed in a future version.)