### PR TITLE
SyntaxWarning tf2-12-4-rnn_long_char.py

### DIFF
--- a/tf2/tf2-12-4-rnn_long_char.py
+++ b/tf2/tf2-12-4-rnn_long_char.py
@@ -51,7 +51,7 @@ tf.model.fit(X_one_hot, Y_one_hot, epochs=100)
 results = tf.model.predict(X_one_hot)
 for j, result in enumerate(results):
     index = np.argmax(result, axis=1)
-    if j is 0:  # print all for the first result to make a sentence
+    if j == 0:  # print all for the first result to make a sentence
         print(''.join([char_set[t] for t in index]), end='')
     else:
         print(char_set[index[-1]], end='')


### PR DESCRIPTION
Since the type of j is int(line54),
using 'is' makes SyntaxWarning.
(<ipython-input-1-d7e33213071a>:54: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if j is 0:  # print all for the first result to make a sentence)

So it is better to use '=='(line 54).