### PR TITLE
fix predict_classes deprecated

### DIFF
--- a/tf2/tf2-06-1-softmax_classifier.py
+++ b/tf2/tf2-06-1-softmax_classifier.py
@@ -48,10 +48,10 @@ print(b, tf.keras.backend.eval(tf.argmax(b, axis=1)))
 print('--------------')
 # or use argmax embedded method, predict_classes
 c = tf.model.predict(np.array([[1, 1, 0, 1]]))
-c_onehot = tf.model.predict_classes(np.array([[1, 1, 0, 1]]))
+c_onehot = np.argmax(c, axis=-1)
 print(c, c_onehot)
 
 print('--------------')
 all = tf.model.predict(np.array([[1, 11, 7, 9], [1, 3, 4, 3], [1, 1, 0, 1]]))
-all_onehot = tf.model.predict_classes(np.array([[1, 11, 7, 9], [1, 3, 4, 3], [1, 1, 0, 1]]))
+all_onehot = np.argmax(all, axis=-1)
 print(all, all_onehot)

--- a/tf2/tf2-06-2-softmax_zoo_classifier.py
+++ b/tf2/tf2-06-2-softmax_zoo_classifier.py
@@ -28,9 +28,9 @@ history = tf.model.fit(x_data, y_one_hot, epochs=1000)
 
 # Single data test
 test_data = np.array([[0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0]]) # expected prediction == 3 (feathers)
-print(tf.model.predict(test_data), tf.model.predict_classes(test_data))
+print(tf.model.predict(test_data), np.argmax(tf.model.predict(test_data), axis=-1))
 
 # Full x_data test
-pred = tf.model.predict_classes(x_data)
+pred = np.argmax(tf.model.predict(x_data), axis=-1)
 for p, y in zip(pred, y_data.flatten()):
     print("[{}] Prediction: {} True Y: {}".format(p == int(y), p, int(y)))


### PR DESCRIPTION
According to Keras release notes, **predict_classes** were removed in 2.6.0.
The code is not run in the latest version.

Therefore, I'd like to propose changing the code to the most suggested solution.

References:
https://cran.r-project.org/web/packages/keras/news/news.html
https://stackoverflow.com/questions/68836551/keras-attributeerror-sequential-object-has-no-attribute-predict-classes
https://discuss.tensorflow.org/t/sequential-object-has-no-attribute-predict-classes/10157
