### PR TITLE
Change parameter `lr` to `learning_rate` for optimizers

### DIFF
--- a/tf2/tf2-02-1-linear_regression.py
+++ b/tf2/tf2-02-1-linear_regression.py
@@ -8,7 +8,7 @@ tf.model = tf.keras.Sequential()
 # units == output shape, input_dim == input shape
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=1))
 
-sgd = tf.keras.optimizers.SGD(lr=0.1)  # SGD == standard gradient descendent, lr == learning rate
+sgd = tf.keras.optimizers.SGD(learning_rate=0.1)  # SGD == standard gradient descendent, lr == learning rate
 tf.model.compile(loss='mse', optimizer=sgd)  # mse == mean_squared_error, 1/m * sig (y'-y)^2
 
 # prints summary of the model to the terminal

--- a/tf2/tf2-03-1-minimizing_cost_show_graph.py
+++ b/tf2/tf2-03-1-minimizing_cost_show_graph.py
@@ -8,9 +8,8 @@ y_train = [0, -1, -2, -3]
 
 tf.model = tf.keras.Sequential()
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=1))
-
-sgd = tf.keras.optimizers.SGD(lr=0.1)
-tf.model.compile(loss='mse', optimizer=sgd)
+sgd = tf.keras.optimizers.SGD(learning_rate=0.1)
+tf.model.compile(loss="mse", optimizer=sgd)
 
 tf.model.summary()
 
@@ -21,9 +20,9 @@ y_predict = tf.model.predict(np.array([5, 4]))
 print(y_predict)
 
 # Plot training & validation loss values
-plt.plot(history.history['loss'])
-plt.title('Model loss')
-plt.ylabel('Loss')
-plt.xlabel('Epoch')
-plt.legend(['Train', 'Test'], loc='upper left')
+plt.plot(history.history["loss"])
+plt.title("Model loss")
+plt.ylabel("Loss")
+plt.xlabel("Epoch")
+plt.legend(["Train", "Test"], loc="upper left")
 plt.show()

--- a/tf2/tf2-04-1-multi_variable_linear_regression.py
+++ b/tf2/tf2-04-1-multi_variable_linear_regression.py
@@ -19,7 +19,7 @@ tf.model.add(tf.keras.layers.Dense(units=1, input_dim=3))  # input_dim=3 gives m
 tf.model.add(tf.keras.layers.Activation('linear'))  # this line can be omitted, as linear activation is default
 # advanced reading https://towardsdatascience.com/activation-functions-neural-networks-1cbd9f8d91d6
 
-tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(lr=1e-5))
+tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(learning_rate=1e-5))
 tf.model.summary()
 history = tf.model.fit(x_data, y_data, epochs=100)
 

--- a/tf2/tf2-04-3-file_input_linear_regression.py
+++ b/tf2/tf2-04-3-file_input_linear_regression.py
@@ -31,7 +31,7 @@ tf.model.add(tf.keras.layers.Dense(units=1, input_dim=3, activation='linear'))
 # tf.model.add(tf.keras.layers.Activation('linear'))
 tf.model.summary()
 
-tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(lr=1e-5))
+tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(learning_rate=1e-5))
 history = tf.model.fit(x_data, y_data, epochs=2000)
 
 # Ask my score

--- a/tf2/tf2-05-1-logistic_regression.py
+++ b/tf2/tf2-05-1-logistic_regression.py
@@ -23,7 +23,7 @@ tf.model.add(tf.keras.layers.Activation('sigmoid'))
 better result with loss function == 'binary_crossentropy', try 'mse' for yourself
 adding accuracy metric to get accuracy report during training
 '''
-tf.model.compile(loss='binary_crossentropy', optimizer=tf.keras.optimizers.SGD(lr=0.01), metrics=['accuracy'])
+tf.model.compile(loss='binary_crossentropy', optimizer=tf.keras.optimizers.SGD(learning_rate=0.01), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=5000)

--- a/tf2/tf2-05-2-logistic_regression_diabetes.py
+++ b/tf2/tf2-05-2-logistic_regression_diabetes.py
@@ -11,7 +11,7 @@ print(x_data.shape, y_data.shape)
 tf.model = tf.keras.Sequential()
 # multi-variable, x_data.shape[1] == feature counts == 8 in this case
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=x_data.shape[1], activation='sigmoid'))
-tf.model.compile(loss='binary_crossentropy', optimizer=tf.keras.optimizers.SGD(lr=0.01),  metrics=['accuracy'])
+tf.model.compile(loss='binary_crossentropy', optimizer=tf.keras.optimizers.SGD(learning_rate=0.01),  metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=500)

--- a/tf2/tf2-06-1-softmax_classifier.py
+++ b/tf2/tf2-06-1-softmax_classifier.py
@@ -31,7 +31,7 @@ tf.model.add(tf.keras.layers.Dense(input_dim=4, units=nb_classes, use_bias=True)
 tf.model.add(tf.keras.layers.Activation('softmax'))
 
 # use loss == categorical_crossentropy
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.SGD(lr=0.1), metrics=['accuracy'])
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.SGD(learning_rate=0.1), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=2000)

--- a/tf2/tf2-06-2-softmax_zoo_classifier.py
+++ b/tf2/tf2-06-2-softmax_zoo_classifier.py
@@ -21,7 +21,7 @@ print("one_hot:", y_one_hot)
 
 tf.model = tf.keras.Sequential()
 tf.model.add(tf.keras.layers.Dense(units=nb_classes, input_dim=16, activation='softmax'))
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.SGD(lr=0.1), metrics=['accuracy'])
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.SGD(learning_rate=0.1), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_one_hot, epochs=1000)

--- a/tf2/tf2-07-1-learning_rate_and_evaluation.py
+++ b/tf2/tf2-07-1-learning_rate_and_evaluation.py
@@ -33,7 +33,7 @@ learning_rate = 0.1
 
 tf.model = tf.keras.Sequential()
 tf.model.add(tf.keras.layers.Dense(units=3, input_dim=3, activation='softmax'))
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.SGD(lr=learning_rate), metrics=['accuracy'])
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.SGD(learning_rate=learning_rate), metrics=['accuracy'])
 
 tf.model.fit(x_data, y_data, epochs=1000)
 

--- a/tf2/tf2-07-2-linear_regression_without_min_max.py
+++ b/tf2/tf2-07-2-linear_regression_without_min_max.py
@@ -16,7 +16,7 @@ y_data = xy[:, [-1]]
 tf.model = tf.keras.Sequential()
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=4))
 tf.model.add(tf.keras.layers.Activation('linear'))
-tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(lr=1e-5))
+tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(learning_rate=1e-5))
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=100)

--- a/tf2/tf2-07-3-linear_regression_min_max.py
+++ b/tf2/tf2-07-3-linear_regression_min_max.py
@@ -43,7 +43,7 @@ y_data = xy[:, [-1]]
 tf.model = tf.keras.Sequential()
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=4))
 tf.model.add(tf.keras.layers.Activation('linear'))
-tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(lr=1e-5))
+tf.model.compile(loss='mse', optimizer=tf.keras.optimizers.SGD(learning_rate=1e-5))
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=1000)

--- a/tf2/tf2-09-1-xor.py
+++ b/tf2/tf2-09-1-xor.py
@@ -7,7 +7,7 @@ y_data = np.array([[0], [1], [1], [0]], dtype=np.float32)
 
 tf.model = tf.keras.Sequential()
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=2, activation='sigmoid'))
-tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.SGD(lr=0.01),  metrics=['accuracy'])
+tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.SGD(learning_rate=0.01),  metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=1000)

--- a/tf2/tf2-09-2-xor-nn.py
+++ b/tf2/tf2-09-2-xor-nn.py
@@ -10,7 +10,7 @@ tf.model.add(tf.keras.layers.Dense(units=2, input_dim=2))
 tf.model.add(tf.keras.layers.Activation('sigmoid'))
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=2))
 tf.model.add(tf.keras.layers.Activation('sigmoid'))
-tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.SGD(lr=0.1),  metrics=['accuracy'])
+tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.SGD(learning_rate=0.1),  metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=10000)

--- a/tf2/tf2-09-3-xor-nn-wide-deep.py
+++ b/tf2/tf2-09-3-xor-nn-wide-deep.py
@@ -15,7 +15,7 @@ tf.model.add(tf.keras.layers.Dense(units=1, activation='sigmoid'))
 
 # SGD not working very well due to vanishing gradient problem, switched to Adam for now
 # or you may use activation='relu', study chapter 10 to know more on vanishing gradient problem.
-tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.Adam(lr=0.1), metrics=['accuracy'])
+tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.Adam(learning_rate=0.1), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_data, y_data, epochs=5000)

--- a/tf2/tf2-09-4-xor_tensorboard.py
+++ b/tf2/tf2-09-4-xor_tensorboard.py
@@ -12,7 +12,7 @@ tf.model.add(tf.keras.layers.Dense(units=2, input_dim=2))
 tf.model.add(tf.keras.layers.Activation('sigmoid'))
 tf.model.add(tf.keras.layers.Dense(units=1, input_dim=2))
 tf.model.add(tf.keras.layers.Activation('sigmoid'))
-tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.SGD(lr=0.1),  metrics=['accuracy'])
+tf.model.compile(loss='binary_crossentropy', optimizer=tf.optimizers.SGD(learning_rate=0.1),  metrics=['accuracy'])
 tf.model.summary()
 
 # prepare callback

--- a/tf2/tf2-10-2-mnist_nn.py
+++ b/tf2/tf2-10-2-mnist_nn.py
@@ -23,7 +23,7 @@ tf.model.add(tf.keras.layers.Dense(input_dim=784, units=256, activation='relu'))
 tf.model.add(tf.keras.layers.Dense(units=256, activation='relu'))
 tf.model.add(tf.keras.layers.Dense(units=nb_classes, activation='softmax'))
 tf.model.compile(loss='categorical_crossentropy',
-                 optimizer=tf.keras.optimizers.Adam(lr=learning_rate), metrics=['accuracy'])
+                 optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate), metrics=['accuracy'])
 tf.model.summary()
 
 tf.model.fit(x_train, y_train, batch_size=batch_size, epochs=training_epochs)

--- a/tf2/tf2-10-3-mnist_nn_xavier.py
+++ b/tf2/tf2-10-3-mnist_nn_xavier.py
@@ -26,7 +26,7 @@ tf.model.add(tf.keras.layers.Dense(input_dim=784, units=256, kernel_initializer=
 tf.model.add(tf.keras.layers.Dense(units=256, kernel_initializer='glorot_normal', activation='relu'))
 tf.model.add(tf.keras.layers.Dense(units=nb_classes, kernel_initializer='glorot_normal', activation='softmax'))
 tf.model.compile(loss='categorical_crossentropy',
-                 optimizer=tf.keras.optimizers.Adam(lr=learning_rate), metrics=['accuracy'])
+                 optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_train, y_train, batch_size=batch_size, epochs=training_epochs)

--- a/tf2/tf2-10-4-mnist_nn_deep.py
+++ b/tf2/tf2-10-4-mnist_nn_deep.py
@@ -28,7 +28,7 @@ tf.model.add(tf.keras.layers.Dense(units=512, kernel_initializer='glorot_normal'
 tf.model.add(tf.keras.layers.Dense(units=512, kernel_initializer='glorot_normal', activation='relu'))
 tf.model.add(tf.keras.layers.Dense(units=nb_classes, kernel_initializer='glorot_normal', activation='softmax'))
 tf.model.compile(loss='categorical_crossentropy',
-                 optimizer=tf.keras.optimizers.Adam(lr=learning_rate), metrics=['accuracy'])
+                 optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_train, y_train, batch_size=batch_size, epochs=training_epochs)

--- a/tf2/tf2-10-5-mnist_nn_dropout.py
+++ b/tf2/tf2-10-5-mnist_nn_dropout.py
@@ -32,7 +32,7 @@ tf.model.add(tf.keras.layers.Dense(units=512, kernel_initializer='glorot_normal'
 tf.model.add(tf.keras.layers.Dropout(drop_rate))
 tf.model.add(tf.keras.layers.Dense(units=nb_classes, kernel_initializer='glorot_normal', activation='softmax'))
 tf.model.compile(loss='categorical_crossentropy',
-                 optimizer=tf.keras.optimizers.Adam(lr=learning_rate), metrics=['accuracy'])
+                 optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate), metrics=['accuracy'])
 tf.model.summary()
 
 history = tf.model.fit(x_train, y_train, batch_size=batch_size, epochs=training_epochs)

--- a/tf2/tf2-11-1-mnist_cnn.py
+++ b/tf2/tf2-11-1-mnist_cnn.py
@@ -33,7 +33,7 @@ tf.model.add(tf.keras.layers.MaxPooling2D(pool_size=(2, 2)))
 tf.model.add(tf.keras.layers.Flatten())
 tf.model.add(tf.keras.layers.Dense(units=10, kernel_initializer='glorot_normal', activation='softmax'))
 
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(lr=learning_rate), metrics=['accuracy'])
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate), metrics=['accuracy'])
 tf.model.summary()
 
 tf.model.fit(x_train, y_train, batch_size=batch_size, epochs=training_epochs)

--- a/tf2/tf2-12-1-hello-rnn.py
+++ b/tf2/tf2-12-1-hello-rnn.py
@@ -37,7 +37,7 @@ tf.model.add(tf.keras.layers.RNN(cell=cell, return_sequences=True))
 # fully connected layer
 tf.model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(units=num_classes, activation='softmax')))
 
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(lr=learning_rate),
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate),
                  metrics=['accuracy'])
 
 # train

--- a/tf2/tf2-12-2-char-seq-rnn.py
+++ b/tf2/tf2-12-2-char-seq-rnn.py
@@ -27,7 +27,7 @@ tf.model.add(tf.keras.layers.
              LSTM(units=num_classes, input_shape=(sequence_length, x_one_hot_eager.shape[2]), return_sequences=True))
 tf.model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(units=num_classes, activation='softmax')))
 tf.model.summary()
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(lr=learning_rate),
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate),
                  metrics=['accuracy'])
 tf.model.fit(x_one_hot_eager, y_one_hot_eager, epochs=50)
 

--- a/tf2/tf2-12-4-rnn_long_char.py
+++ b/tf2/tf2-12-4-rnn_long_char.py
@@ -43,7 +43,7 @@ tf.model.add(tf.keras.layers.
 tf.model.add(tf.keras.layers.LSTM(units=num_classes, return_sequences=True))
 tf.model.add(tf.keras.layers.TimeDistributed(tf.keras.layers.Dense(units=num_classes, activation='softmax')))
 tf.model.summary()
-tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(lr=learning_rate),
+tf.model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate),
                  metrics=['accuracy'])
 tf.model.fit(X_one_hot, Y_one_hot, epochs=100)
 

--- a/tf2/tf2-12-5-rnn_stock_prediction.py
+++ b/tf2/tf2-12-5-rnn_stock_prediction.py
@@ -75,7 +75,7 @@ tf.model.add(tf.keras.layers.LSTM(units=1, input_shape=(seq_length, data_dim)))
 tf.model.add(tf.keras.layers.Dense(units=output_dim, activation='tanh'))
 tf.model.summary()
 
-tf.model.compile(loss='mean_squared_error', optimizer=tf.keras.optimizers.Adam(lr=learning_rate))
+tf.model.compile(loss='mean_squared_error', optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate))
 tf.model.fit(trainX, trainY, epochs=iterations)
 
 


### PR DESCRIPTION
# Problem

```
WARNING:absl:`lr` is deprecated in Keras optimizer, 
please use `learning_rate` or use the legacy optimizer, e.g.,tf.keras.optimizers.legacy.SGD.
```

In Keras optimizers version 2.3.0, the `lr` parameter has been deprecated. It should be replaced with `learning_rate`.

[View Keras 2.3.0 Release Notes](https://github.com/keras-team/keras/releases/tag/2.3.0)

# Change

Change all occurrences of the `lr` parameter to `learning_rate` in all files located in the `tf2/` directory.